### PR TITLE
Display caption for individual thumbnails, and add link to file properties

### DIFF
--- a/modules/ext.FancyBoxThumbs.js
+++ b/modules/ext.FancyBoxThumbs.js
@@ -22,7 +22,13 @@
         }
 
         //attach new path to this link
-        $(this).attr("href", new_img_src).attr("rel", "group").addClass('fancybox');
+        var title = $(this).attr("title") || $(this).next(".thumbcaption").text();
+        title = (title !== "")?title + " - ":"";
+        $(this)
+          .data("fancybox-href", new_img_src)
+          .data("fancybox-title", title + '<a href="' + $(this).attr("href") + '">more info</a>')
+          .attr("rel", "group")
+          .addClass('fancybox');
     });
 
     //now set fancybox on all thumbnail links


### PR DESCRIPTION
This change also displays the image caption in the lightbox if it was an
individual thumbnail image. Also, it adds a link to the MediaWiki info
page for the file, which may have more details, so this remains accessible
when using the lightbox plugin.

Author: Jos Visser
